### PR TITLE
margin issue on empty title fixed

### DIFF
--- a/src/components/Result.svelte
+++ b/src/components/Result.svelte
@@ -35,11 +35,7 @@
 
   <div class="info" title={result.title}> 
     <h4 class="title">{result.title}</h4> 
-    {#if result.title}
-    <p class="url">{result.url}</p>
-    {:else}
-    <p class="url-2">{result.url}</p>
-    {/if}
+    <p class="url" style={!result.title ? "margin-top:0" : ""}>{result.url}</p>
   </div>
 </li>
 
@@ -92,10 +88,5 @@
     font-size: 12px;
     color: #4A5568;
     margin-top: 4px;
-  }
-
-  .url-2{
-    font-size: 12px;
-    color: #4A5568;
   }
 </style>

--- a/src/components/Result.svelte
+++ b/src/components/Result.svelte
@@ -33,9 +33,13 @@
     <span class="favicon-placeholder" />
   {/if}
 
-  <div class="info" title={result.title}>
-    <h4 class="title">{result.title}</h4>
+  <div class="info" title={result.title}> 
+    <h4 class="title">{result.title}</h4> 
+    {#if result.title}
     <p class="url">{result.url}</p>
+    {:else}
+    <p class="url-2">{result.url}</p>
+    {/if}
   </div>
 </li>
 
@@ -88,5 +92,10 @@
     font-size: 12px;
     color: #4A5568;
     margin-top: 4px;
+  }
+
+  .url-2{
+    font-size: 12px;
+    color: #4A5568;
   }
 </style>


### PR DESCRIPTION
Issue #19 

In rare cases when the title was not there, URL was having a 4px top margin. Fixed that by putting conditional statements and introducing a new class .url-2 

Image - 

<img src="https://i.imgur.com/Y8jYfan.jpg">