### PR TITLE
Modified Results.svelte to pluralize result(s) based on number of results

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -251,6 +251,6 @@ chrome.commands.onCommand.addListener((command) => {
 chrome.browserAction.onClicked.addListener((tab) => {
   chrome.tabs.sendMessage(tab.id, {
     type: constants.OPEN,
-    data: query,
+    data: search.query,
   });
 });

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -251,6 +251,6 @@ chrome.commands.onCommand.addListener((command) => {
 chrome.browserAction.onClicked.addListener((tab) => {
   chrome.tabs.sendMessage(tab.id, {
     type: constants.OPEN,
-    data: search.query,
+    data: search,
   });
 });

--- a/src/components/Results.svelte
+++ b/src/components/Results.svelte
@@ -8,10 +8,9 @@
   let focusedIdx;
 
   // Reset focused result to be first result when the results get updated
-  let flag = false;
+
   const unsubscribe = results.subscribe(() => {
     focusedIdx = keyNavArray($results);
-    flag = $results.length>1?true:false;
   });
 
   onDestroy(unsubscribe);
@@ -31,7 +30,7 @@
   </ul>
   <footer>
     <span>
-      {$results.length} {#if flag } results {:else} result{/if}
+      {$results.length} {#if $results.length>1} results {:else} result{/if}
     </span>
     <span>
       ↑ and ↓ to navigate, ↲ to select

--- a/src/components/Results.svelte
+++ b/src/components/Results.svelte
@@ -8,12 +8,13 @@
   let focusedIdx;
 
   // Reset focused result to be first result when the results get updated
+  let flag = false;
   const unsubscribe = results.subscribe(() => {
     focusedIdx = keyNavArray($results);
+    flag = $results.length>1?true:false;
   });
 
   onDestroy(unsubscribe);
-
 </script>
 
 {#if $results.length}
@@ -30,7 +31,7 @@
   </ul>
   <footer>
     <span>
-      {$results.length} results
+      {$results.length} {#if flag } results {:else} result{/if}
     </span>
     <span>
       ↑ and ↓ to navigate, ↲ to select


### PR DESCRIPTION
This PR fixes #29 

In the `Results.svlete` page, the length of results was checked if it greater than 1 or not and the result(s) text was pluralized accordingly. This PR also fixed an unnoticed bug which said "query not defined" in the extension's console.

Screenshots are attached:

<img src = "https://user-images.githubusercontent.com/31794134/96349870-00f17c00-10d0-11eb-9214-f6ec2fa795e3.png">
<img src = "https://user-images.githubusercontent.com/31794134/96349872-0222a900-10d0-11eb-886b-38e6eab9de6f.png">




 