### PR TITLE
Fix missing Firefox favicons

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,5 +28,5 @@
     "chrome://favicon/",
     "storage"
   ],
-  "content_security_policy": "script-src 'self'; object-src 'self'; img-src http: https: chrome://favicon;"
+  "content_security_policy": "script-src 'self'; object-src 'self'; img-src http: https: data: chrome://favicon;"
 }


### PR DESCRIPTION
Fixes #4 

Hi @blenderskool  I just tested it in Firefox and I think the favicons were not loaded because of *content security policy* about data in img src, I don't know in Chrome but in Firefox favicons URLs are returned in base64.

Here is a preview of untab working in Firefox 82.
![image](https://user-images.githubusercontent.com/7670276/97701632-01195080-1aae-11eb-8f24-4d4e5cb5f5e3.png)

An interesting project, I used this functionality in Opera in the past but miss it in Firefox.
