### PR TITLE
Initial implementation of DuckDuckGo Instant answer

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,7 +26,8 @@
     "history",
     "bookmarks",
     "chrome://favicon/",
-    "storage"
+    "storage",
+    "https://api.duckduckgo.com/*"
   ],
   "content_security_policy": "script-src 'self'; object-src 'self'; img-src http: https: data: chrome://favicon;"
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,5 +28,5 @@
     "chrome://favicon/",
     "storage"
   ],
-  "content_security_policy": "script-src 'self'; object-src 'self'; img-src http: https: chrome://favicon;"
+  "content_security_policy": "script-src 'self'; object-src 'self'; img-src http: https: data: chrome://favicon;"
 }


### PR DESCRIPTION
Fixes #36 

I made a very basic initial implementation of Initial DuckDuckGo Instant answer adding provided results, abstract and related topics to the current search functionality.

Here is an example:
![image](https://user-images.githubusercontent.com/7670276/97727796-18b60080-1ad1-11eb-8960-37c93e744aba.png)

There's room for improvement, but I'd rather start with that to see if it's what you like.