### PR TITLE
Initial implementation of DuckDuckGo Instant answer

### DIFF
--- a/src/background/plugins.js
+++ b/src/background/plugins.js
@@ -86,12 +86,16 @@ export default {
 
       if (query.length > 3) {
         const category = 'Instant answer';
+        const parseIconUrl = (url) => {
+          if (!url || url === '') return 'https://duckduckgo.com/favicon.ico'
+          return url.indexOf('http') === 0 ? url : 'https://duckduckgo.com' + url
+        }
         try {
           const search = await fetch(`https://api.duckduckgo.com/?q=${encodeURI(query)}&format=json`).then(response => response.json());
 
           if (search.Abstract) {
             results.push({
-              favicon: search.Image,
+              favicon: parseIconUrl(search.Image),
               title: search.AbstractText,
               url: search.AbstractURL,
               category,
@@ -99,7 +103,7 @@ export default {
           }
 
           results.push(...search.Results.map(result => ({
-            favicon: result.Icon?.URL,
+            favicon: parseIconUrl(result.Icon?.URL),
             title: result.Text,
             url: result.FirstURL,
             category,
@@ -109,7 +113,7 @@ export default {
             ...search.RelatedTopics
               .filter(topic => !!topic.FirstURL)
               .map(topic => ({
-                favicon: topic.Icon?.URL,
+                favicon: parseIconUrl(topic.Icon?.URL),
                 title: topic.Text,
                 url: topic.FirstURL,
                 category,

--- a/src/background/plugins.js
+++ b/src/background/plugins.js
@@ -87,9 +87,10 @@ export default {
       if (query.length > 3) {
         const category = 'Instant answer';
         const parseIconUrl = (url) => {
-          if (!url || url === '') return 'https://duckduckgo.com/favicon.ico'
-          return url.indexOf('http') === 0 ? url : 'https://duckduckgo.com' + url
-        }
+          if (!url || url === '') return;
+          return url.indexOf('http') === 0 ? url : 'https://duckduckgo.com' + url;
+        };
+
         try {
           const search = await fetch(`https://api.duckduckgo.com/?q=${encodeURI(query)}&format=json`).then(response => response.json());
 

--- a/src/background/plugins.js
+++ b/src/background/plugins.js
@@ -85,25 +85,27 @@ export default {
       const results = []
       if (query.length > 3) {
         const category = 'Instant answer'
-        const search = await fetch(`https://api.duckduckgo.com/?q=${encodeURI(query)}&format=json`).then(response => response.json())
-        if (search.Abstract) results.push({
-          favicon: search.Image,
-          title: search.AbstractText,
-          url: search.AbstractURL,
-          category
-        })
-        results.push(...search.Results.map(result => ({
-          favicon: result.Icon.URL,
-          title: result.Text,
-          url: result.FirstURL,
-          category
-        })))
-        results.push(...search.RelatedTopics.map(topic => ({
-          favicon: topic.Icon.URL,
-          title: topic.Text,
-          url: topic.FirstURL,
+        try {
+          const search = await fetch(`https://api.duckduckgo.com/?q=${encodeURI(query)}&format=json`).then(response => response.json())
+          if (search.Abstract) results.push({
+            favicon: search.Image,
+            title: search.AbstractText,
+            url: search.AbstractURL,
             category
-        })))
+          })
+          results.push(...search.Results.map(result => ({
+            favicon: result.Icon.URL,
+            title: result.Text,
+            url: result.FirstURL,
+            category
+          })))
+          results.push(...search.RelatedTopics.map(topic => ({
+            favicon: topic.Icon.URL,
+            title: topic.Text,
+            url: topic.FirstURL,
+              category
+          })))
+        } catch {}
       }
       return [
         {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,7 +26,8 @@
     "history",
     "bookmarks",
     "chrome://favicon/",
-    "storage"
+    "storage",
+    "https://api.duckduckgo.com/*"
   ],
-  "content_security_policy": "script-src 'self'; object-src 'self'; img-src http: https: chrome://favicon;"
+  "content_security_policy": "script-src 'self'; object-src 'self'; img-src http: https: data: chrome://favicon;"
 }


### PR DESCRIPTION
Fixes #36 

I made a very basic initial implementation of Initial DuckDuckGo Instant answer adding provided results, abstract and related topics to the current search functionality.

Here is an example:
![image](https://user-images.githubusercontent.com/7670276/97727796-18b60080-1ad1-11eb-8960-37c93e744aba.png)

There's room for improvement, but I'd rather start with that to see if it's what you like.