### PR TITLE
Add plugin for recently closed tabs/windows

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -135,7 +135,7 @@ async function searchData({ data }) {
 
   return {
     length: results.length,
-    items: groupItems(results, [ 'Tabs', 'Plugins' ]),
+    items: groupItems(results, [ 'Recently Closed', 'Tabs', 'Plugins' ]),
     match: results?.[0]?.matches,
   };
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,4 +7,5 @@ export default {
   OPEN: 'open',
   SELECT_PORT: 'select-port',
   PLUGIN: 'plugin',
+  RECENTS_DURATION: '60', // Duration in seconds.
 };

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -38,7 +38,8 @@
   "permissions": [
     "tabs",
     "chrome://favicon/",
-    "storage"
+    "storage",
+    "sessions"
   ],
   "optional_permissions": [
     "bookmarks",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -34,7 +34,8 @@
     "history",
     "bookmarks",
     "storage",
-    "https://api.duckduckgo.com/*"
+    "https://api.duckduckgo.com/*",
+    "sessions"
   ],
   "content_security_policy": "script-src 'self'; object-src 'self'; img-src http: https: data:"
 }


### PR DESCRIPTION
Added a plugin for recently closed tabs. Duration to qualify for 'recently closed' is 60 seconds (defined in constants.js). The initial idea was to show tabs that might have been closed accidentally, hence the short duration.