### PR TITLE
Updated upload instruction for manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ All the built files are generated in the `dist` directory.
 - Go to `chrome://extensions`.
 - Turn ON `Developer mode`.
 - Click on `Load Unpacked`.
-- The `manifest.json` file that was generated after the build step, should be uploaded. Select the `dist` folder after clicking on `Load Unpacked` and it will check for manifest on its own. The extension should now show up on the list.
+- Select the `dist` folder and it will check for `manifest.json` on its own. The extension should now show up on the list.
 - Go to any page and press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> or <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> (on Mac) to open UnTab.
 - NOTE: Whenever, the build files are changed, to get the changes synced with the installed extension, click on the reload icon next to the installed extension.
 
 #### Firefox
 - Go to `about:debugging` and select `This Firefox` on the left sidebar.
 - Click on `Load Temporary Add-on...` button.
-- Select the `manifest.json` file in `dist` folder that was generated after the build step. The extension should now show up on the list.
+- Select the `dist` folder and it will check for `manifest.json` on its own. The extension should now show up on the list.
 - Go to any page and press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> or <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> (on Mac) to open UnTab.
 - NOTE: Whenever, the build files are changed, to get the changes synced with the installed extension, click on the `Reload` button in the extension that was installed in the 3rd step.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ All the built files are generated in the `dist` directory.
 - Go to `chrome://extensions`.
 - Turn ON `Developer mode`.
 - Click on `Load Unpacked`.
-- Select the `manifest.json` file in `dist` folder that was generated after the build step. The extension should now show up on the list.
+- The `manifest.json` file that was generated after the build step, should be uploaded. Select the `dist` folder after clicking on `Load Unpacked` and it will check for manifest on its own. The extension should now show up on the list.
 - Go to any page and press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> or <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> (on Mac) to open UnTab.
 - NOTE: Whenever, the build files are changed, to get the changes synced with the installed extension, click on the reload icon next to the installed extension.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All the built files are generated in the `dist` directory.
 #### Firefox
 - Go to `about:debugging` and select `This Firefox` on the left sidebar.
 - Click on `Load Temporary Add-on...` button.
-- Select the `dist` folder and it will check for `manifest.json` on its own. The extension should now show up on the list.
+- Select the `manifest.json` file in `dist` folder that was generated after the build step. The extension should now show up on the list.
 - Go to any page and press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> or <kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> (on Mac) to open UnTab.
 - NOTE: Whenever, the build files are changed, to get the changes synced with the installed extension, click on the `Reload` button in the extension that was installed in the 3rd step.
 


### PR DESCRIPTION
The previous instruction regarding the step where we upload the ```manifest.json``` was bit unclear. Since it did not specifically say anything about selecting the ```dist``` folder or the application searching for the ```manifest.json``` on its own inside the ```dist``` folder. Thus it became a bit confusing for newbies, since the ```manifest.json``` did not show up upon trying to upload it.. The updated instruction step however specifies the previously missing information.