### PR TITLE
Plugins UI 🎉

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ['https://www.buymeacoffee.com/AkashHamirwasia']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,10 +126,10 @@ Navigate to UnTab repository [Pull requests](https://github.com/blenderskool/unt
 - **Important:** Make sure to add `Fixes #<issue-id>` if your pull request fixes some already open issue.
 
 ## Contributing a Plugin
-Plugins are independent modules of code that expand the existing functionality of UnTab. These plugins are located in the `src/background/plugins.js` file.
+Plugins are independent modules of code that expand the existing functionality of UnTab. These plugins are located in the `src/plugins/` directory.
 
 - Start by following the steps in **Contributing to Code** above to setup the repository on your local machine.
-- Add the code for your new plugin in the `src/background/plugins.js` file. (Link to Plugins API wiki coming soon!)
+- Add the code for your new plugin in the `src/plugins/index.js` file. (Link to Plugins API wiki coming soon!)
 - Once you have added the plugin and tested it, commit your changes and open a Pull request (Follow the steps in **Contributing to Code** above).
 
 
@@ -147,7 +147,7 @@ Theme gives a unique look to UnTab. There are themes present in the extension al
     ...
 }
 ```
-- Once the theme styles are defined, add the entry of your theme in `src/background/plugins.js` under the `themes` plugin. Example:
+- Once the theme styles are defined, add the entry of your theme in `src/plugins/index.js` under the `themes` plugin. Example:
 ```js
 {
 'themes': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,14 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/plugin-alias": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.2.tgz",
+      "integrity": "sha512-wzDnQ6v7CcoRzS0qVwFPrFdYA4Qlr+ookA217Y2Z3DPZE1R8jrFNM3jvGgOf6o6DMjbnQIn5lCIJgHPe1Bt3uw==",
+      "requires": {
+        "slash": "^3.0.0"
+      }
+    },
     "@rollup/plugin-commonjs": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-14.0.0.tgz",
@@ -632,6 +640,11 @@
         "is-plain-object": "^3.0.0"
       }
     },
+    "rollup-plugin-ignore-import": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-ignore-import/-/rollup-plugin-ignore-import-1.3.2.tgz",
+      "integrity": "sha512-q7yH2c+PKVfb61+MTXqqyBHIgflikumC7OEB+OfQWNsSmDqE5FLZLeewcBGl1VDmjDjSXuALXsaBjyIsl3oNmQ=="
+    },
     "rollup-plugin-svelte": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.0.1.tgz",
@@ -696,8 +709,7 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "build": "rollup -c",
     "build:firefox": "BROWSER_ENV=firefox npm run build",
     "build:chrome": "BROWSER_ENV=chrome npm run build",
-
     "build:prod": "NODE_ENV=production npm run build",
     "build:prod:firefox": "BROWSER_ENV=firefox npm run build:prod",
     "build:prod:chrome": "BROWSER_ENV=chrome npm run build:prod"
@@ -21,7 +20,9 @@
     "svelte": "^3.0.0"
   },
   "dependencies": {
+    "@rollup/plugin-alias": "^3.1.2",
     "fuse.js": "^6.4.1",
+    "rollup-plugin-ignore-import": "^1.3.2",
     "svelte-feather-icons": "^3.2.2",
     "uuid": "^8.3.2",
     "webextension-polyfill": "^0.7.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,12 @@
+import path from 'path';
 import svelte from 'rollup-plugin-svelte';
 import replace from '@rollup/plugin-replace';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import alias from '@rollup/plugin-alias';
 import { terser } from 'rollup-plugin-terser';
 import copy from 'rollup-plugin-copy';
+import ignoreImport from 'rollup-plugin-ignore-import';
 
 const production = !process.env.ROLLUP_WATCH;
 const BROWSER_ENV = process.env.BROWSER_ENV || 'chrome';
@@ -24,6 +27,12 @@ export default [
       file: 'dist/untab.js',
     },
     plugins: [
+      alias({
+        entries: [
+          { find: '@untab/plugins-ui', replacement: path.resolve(path.resolve(__dirname), 'src/components/plugin-ui/') },
+        ]
+      }),
+  
       svelte({
         // enable run-time checks when not in production
         dev: !production,
@@ -89,6 +98,14 @@ export default [
       file: 'dist/background.js',
     },
     plugins: [
+      /**
+       * Svelte components should not be imported in background script
+       * bundle as it won't be used. Hence it gets stubbed
+       */
+      ignoreImport({
+        extensions: ['.svelte'],
+        body: 'export default undefined;'
+      }),
       resolve({
         browser: true,
       }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,6 +27,7 @@ export default [
       file: 'dist/untab.js',
     },
     plugins: [
+      // @untab/plugins-ui is aliased to the directory with plugin ui components
       alias({
         entries: [
           { find: '@untab/plugins-ui', replacement: path.resolve(path.resolve(__dirname), 'src/components/plugin-ui/') },

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -229,9 +229,14 @@ browser.runtime.onConnect.addListener(port => {
            * Plugin events are executed by calling the appropraite
            * handlers which are specified in the event object.
            * The arguments to the handler are also passed as specified
-           * by the caller. 
+           * by the caller.
            */
           await plugins[item.name].methods[item.event](...item.args);
+
+          /**
+           * autoClose is set to false as plugin events do not complete a primary UnTab action
+           * refetch is true as executing plugin event might require refetching the results in case something was changed by the event
+           */
           results.autoClose = false;
           results.refetch = true;
           break;

--- a/src/components/Input/Input.svelte
+++ b/src/components/Input/Input.svelte
@@ -86,7 +86,7 @@
     switch (key) {
       case 'ArrowRight':
         const { selectionStart, selectionEnd } = input;
-        if (selectionEnd === selectionStart && selectionStart === $searchVal.query.length) {
+        if (suggestion && selectionEnd === selectionStart && selectionStart === $searchVal.query.length) {
           searchVal.update(s => ({ ...s, query: s.query + suggestion }));
           suggestion = '';
         }

--- a/src/components/Result.svelte
+++ b/src/components/Result.svelte
@@ -1,6 +1,7 @@
 <script>
   import { createEventDispatcher } from 'svelte';
   import constants from '../constants';
+  import plugins from '../plugins';
 
   export let result, isFocused = false;
 
@@ -13,6 +14,19 @@
     if (key && (key !== 'Enter' || !isFocused)) return;
 
     dispatch('select', result);
+  }
+
+  /**
+   * Dispatches the event from plugin with appropriate
+   * data attached to reach the correct receiver.
+   */
+  function handlePluginEvent(event, ...args) {
+    dispatch('pluginEvent', {
+      event,
+      args,
+      name: result.name,
+      type: constants.PLUGIN_EVENT
+    });
   }
 
   $: if (isFocused && element) {
@@ -36,6 +50,12 @@
     <h4 class="title">{result.title}</h4> 
     <p class="url" style={!result.title ? "margin-top:0" : ""}>{result.url}</p>
   </div>
+
+  {#if plugins[result.name]?.ui}
+    <div class="slot" on:click|stopPropagation>
+      <svelte:component this={plugins[result.name].ui} item={result} event={handlePluginEvent} />
+    </div>
+  {/if}
 </li>
 
 
@@ -102,5 +122,10 @@
     font-size: 12px;
     color: var(--gray-700);
     margin-top: 4px;
+  }
+
+  .slot {
+    margin-left: 10px;
+    display: flex;
   }
 </style>

--- a/src/components/Results.svelte
+++ b/src/components/Results.svelte
@@ -72,7 +72,7 @@
     {/each}
   </ul>
   <footer>
-    <a href="https://paypal.me/akashhamirwasia" class="support" target="blank">
+    <a href="https://www.buymeacoffee.com/akashhamirwasia" class="support" target="blank">
       <span style="margin-right: 2px">💙</span>
       Support UnTab
     </a>

--- a/src/components/Results.svelte
+++ b/src/components/Results.svelte
@@ -14,11 +14,14 @@
   const dispatch = createEventDispatcher();
 
   const port = browser.runtime.connect({ name: constants.SELECT_PORT });
-  port.onMessage.addListener(({ autoClose, ...storage }) => {
+  port.onMessage.addListener(({ autoClose, refetch, ...storage }) => {
     storedKeys.update((obj) => ({ ...obj, ...storage }));
-
     if (autoClose !== false) {
       dispatch('select');
+    }
+
+    if (refetch === true){
+      searchVal.update(s => s);
     }
   });
 
@@ -29,6 +32,12 @@
     } else {
       port.postMessage({ data: result });
     }
+  }
+  
+  async function handlePluginEvent({ detail: data }) {
+    if (!data.name || !data.event) return;
+
+    port.postMessage({ data });
   }
 
   // Reset focused result to be first result when the results get updated
@@ -52,7 +61,12 @@
         </div>
 
         {#each $results.items[category] as item}
-          <Result result={item} isFocused={item.idx === $focusedIdx} on:select={handleSelect} />
+          <Result
+            result={item}
+            isFocused={item.idx === $focusedIdx}
+            on:select={handleSelect}
+            on:pluginEvent={handlePluginEvent}
+          />
         {/each}
       </div>
     {/each}

--- a/src/components/plugin-ui/Button.svelte
+++ b/src/components/plugin-ui/Button.svelte
@@ -2,9 +2,9 @@
   export let title;
 </script>
 
-<div class="plugin-btn" title={title} on:click>
+<button class="plugin-btn" title={title} on:click>
   <slot />
-</div>
+</button>
 
 <style>
   .plugin-btn {

--- a/src/components/plugin-ui/Button.svelte
+++ b/src/components/plugin-ui/Button.svelte
@@ -1,0 +1,35 @@
+<script>
+  export let title;
+</script>
+
+<div class="plugin-btn" title={title} on:click>
+  <slot />
+</div>
+
+<style>
+  .plugin-btn {
+    background-color: var(--bg-pill);
+    color: var(--gray-800);
+    padding: 0.2rem 0.4rem;
+    min-width: 25px;
+    min-height: 25px;
+    display: inline-flex;
+    border-radius: 4px;
+    border: 1px solid var(--gray-500);
+    margin-left: 8px;
+    font-weight: 600;
+    font-size: 0.875rem;
+    letter-spacing: 0.025rem;
+    transform: transition 0.2s ease;
+  }
+  .plugin-btn:first-of-type {
+    margin-left: 0;
+  }
+  .plugin-btn:hover {
+    transform: scale(1.05);
+  }
+
+  :global(.plugin-btn svg) {
+    width: 17px !important;
+  }
+</style>

--- a/src/components/plugin-ui/index.js
+++ b/src/components/plugin-ui/index.js
@@ -1,0 +1,1 @@
+export { default as Button } from './Button.svelte';

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,4 +7,5 @@ export default {
   OPEN: 'open',
   SELECT_PORT: 'select-port',
   PLUGIN: 'plugin',
+  PLUGIN_EVENT: 'plugin-event',
 };

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,25 +1,9 @@
-import getFaviconUrl from './utils/getFaviconUrl';
-import checkPermission from './utils/checkPermission';
+import getFaviconUrl from '../background/utils/getFaviconUrl';
+import checkPermission from '../background/utils/checkPermission';
+import tabs from './tabs/tabs';
 
 export default {
-  'tabs': {
-    async item() {
-      const tabs = await browser.tabs.query({});
-
-      return tabs.map(({ windowId, title, favIconUrl, url, id }) => ({
-        id,
-        windowId,
-        title,
-        url,
-        favicon: favIconUrl,
-        category: 'Tabs',
-      }));
-    },
-    async handler(item) {
-      await browser.windows.update(item.windowId, { focused: true });
-      await browser.tabs.update(item.id, { active: true });
-    }
-  },
+  'tabs': tabs,
   'tab-actions': {
     displayName: 'Tab actions',
     keys: [ 't', 'tab' ],

--- a/src/plugins/tabs/Tabs.svelte
+++ b/src/plugins/tabs/Tabs.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { Button } from '@untab/plugins-ui';
+  import { XIcon } from 'svelte-feather-icons';
+
+  export let item, event;
+</script>
+
+<Button on:click={() => event('togglePin', item.id, !item.pinned)} title="Toggle tab pin on/off">
+  {#if item.pinned}
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M0 0h24v24H0z" stroke="none"/><path d="M3 3l18 18M15 4.5l-3.249 3.249m-2.57 1.433L7 10l-1.5 1.5 7 7L14 17l.82-2.186m1.43-2.563L19.5 9M9 15l-4.5 4.5M14.5 4L20 9.5"/></svg>
+  {:else}
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M0 0h24v24H0z" stroke="none"/><path d="M15 4.5l-4 4L7 10l-1.5 1.5 7 7L14 17l1.5-4 4-4M9 15l-4.5 4.5M14.5 4L20 9.5"/></svg>
+  {/if}
+</Button>
+
+<Button on:click={() => event('close', item.id)} title="Close tab">
+  <XIcon />
+</Button>

--- a/src/plugins/tabs/tabs.js
+++ b/src/plugins/tabs/tabs.js
@@ -1,0 +1,35 @@
+import Tabs from './Tabs.svelte';
+
+export default {
+  ui: Tabs,
+  async item() {
+    const tabs = (await Promise.all([
+      // Query audible tabs first
+      browser.tabs.query({ audible: true }),
+      // Then other tabs
+      browser.tabs.query({ audible: false })
+    ])).flat();
+
+    return tabs.map(({ windowId, title, favIconUrl, url, id, audible, mutedInfo: { muted }, pinned }) => ({
+      id,
+      windowId,
+      title: audible ? `${muted ? '🔇' : '🔊'} ${title}` : title,
+      pinned,
+      url,
+      favicon: favIconUrl,
+      category: 'Tabs',
+    }));
+  },
+  async handler(item) {
+    await browser.windows.update(item.windowId, { focused: true });
+    await browser.tabs.update(item.id, { active: true });
+  },
+  methods: {
+    async close(tabId) {
+      await browser.tabs.remove(tabId);
+    },
+    async togglePin(tabId, state) {
+      await browser.tabs.update(tabId, { pinned: state });
+    },
+  },
+};


### PR DESCRIPTION
### Why Plugins UI?
Plugins in UnTab were just about providing results for the search index, and executing appropriate logic when a result was selected. While this served many use-cases, it started to feel like plugins needed more control over how they render the results and the other actions they'd support for each result. Thus, some **UI-level control for the plugins** seemed like the way to go.

### How does this PR add the feature?
With UnTab Plugins UI, each plugin can now specify what they want to render for each result the plugin provides by simply defining it as a **Svelte component** :orange_heart:! With the power of Svelte components, these pieces of UI can have their own state, styles, and logic making plugins even more flexible. These Svelte components are only bundled with the content script bundle and are not a part of the background script bundle(as the UI part is irrelevant in the background script).

Another important piece of UI is **interactivity**. Interactivity is what allows buttons rendered in the UI to perform some action. This has been made possible through a basic event system where the UI calls an event with an appropriate name and arguments, and UnTab delegates this call to the handler specified in the plugins definition in the background script.

### Example of how it works
Here's an example of how the new plugin UI works in the tabs search plugin. The plugin provides actions to pin/unpin tabs and close the tabs.

https://user-images.githubusercontent.com/21107799/118397502-ee452280-b671-11eb-90ee-030a42c67444.mp4

### What if the plugin level UI becomes inconsistent over time?
Now that each plugin can specify its own CSS for the UI, there might be cases when styles of different plugins are inconsistent causing a bad UX overall. Also, the UI might start to get cluttered with buttons and text even more if it's not controlled. To control these problems, the following guidelines should be followed:
- Plugins UI should be used only when it's _very_ necessary.
- A new set of simple UI components would be added like Buttons, that should be used to remain consistent with the overall look of UnTab. These UI components can be imported via `@untab/plugins-ui`. Currently, only a `Button` component is exported from this.
- We should do very strict checks for PRs that add/update plugin level UI to be consistent with the rest of the extension.

### Other changes in this PR
- Updated sponsor link.
- Add audio indicator for the tabs. Fixes #50.
- Add buttons to pin/unpin and close tabs. Fixes #53.
- Plugins definition file has been changed from `src/background/plugins.js` to `src/plugins/index.js`